### PR TITLE
feat: add admin dashboard for operations management

### DIFF
--- a/src/app/api/admin/alerts/route.ts
+++ b/src/app/api/admin/alerts/route.ts
@@ -1,0 +1,52 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+interface AlertRequest {
+  title: string;
+  message: string;
+  severity?: 'info' | 'warning' | 'critical';
+  activeUntil?: string | null;
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as AlertRequest;
+    const { title, message, severity = 'info', activeUntil } = body;
+
+    if (!title || !message) {
+      return NextResponse.json({
+        success: false,
+        error: 'Título e mensagem são obrigatórios para criar um alerta.',
+      }, { status: 400 });
+    }
+
+    const payload: Record<string, unknown> = {
+      title,
+      message,
+      severity,
+      active: true,
+    };
+
+    if (activeUntil) {
+      payload.active_until = activeUntil;
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('alerts')
+      .insert(payload)
+      .select()
+      .single();
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return NextResponse.json({ success: true, alert: data });
+  } catch (error) {
+    console.error('Erro ao criar alerta:', error);
+    return NextResponse.json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Erro desconhecido ao criar alerta.',
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/chat/route.ts
+++ b/src/app/api/admin/chat/route.ts
@@ -1,0 +1,101 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+interface ChatMessagePayload {
+  threadId: string;
+  message: string;
+  closeThread?: boolean;
+}
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const threadId = searchParams.get('threadId');
+
+  try {
+    if (threadId) {
+      const { data, error } = await supabaseAdmin
+        .from('chat_messages')
+        .select('id, thread_id, sender_type, message, created_at')
+        .eq('thread_id', threadId)
+        .order('created_at', { ascending: true });
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return NextResponse.json({ success: true, messages: data ?? [] });
+    }
+
+    const { data, error } = await supabaseAdmin
+      .from('chat_threads')
+      .select('id, profile_id, subject, status, created_at, updated_at, unread_count')
+      .order('updated_at', { ascending: false })
+      .limit(50);
+
+    if (error) {
+      throw new Error(error.message);
+    }
+
+    return NextResponse.json({ success: true, threads: data ?? [] });
+  } catch (error) {
+    console.error('Erro ao consultar chat:', error);
+    return NextResponse.json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Erro desconhecido ao consultar mensagens.',
+    }, { status: 500 });
+  }
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as ChatMessagePayload;
+    const { threadId, message, closeThread } = body;
+
+    if (!threadId || !message) {
+      return NextResponse.json({
+        success: false,
+        error: 'Thread e mensagem são obrigatórios.',
+      }, { status: 400 });
+    }
+
+    const { error: messageError } = await supabaseAdmin
+      .from('chat_messages')
+      .insert({
+        thread_id: threadId,
+        sender_type: 'admin',
+        message,
+      });
+
+    if (messageError) {
+      throw new Error(messageError.message);
+    }
+
+    if (closeThread) {
+      const { error: threadError } = await supabaseAdmin
+        .from('chat_threads')
+        .update({ status: 'closed' })
+        .eq('id', threadId);
+
+      if (threadError) {
+        throw new Error(threadError.message);
+      }
+    } else {
+      const { error: threadUpdateError } = await supabaseAdmin
+        .from('chat_threads')
+        .update({ status: 'active', unread_count: 0 })
+        .eq('id', threadId);
+
+      if (threadUpdateError) {
+        throw new Error(threadUpdateError.message);
+      }
+    }
+
+    return NextResponse.json({ success: true });
+  } catch (error) {
+    console.error('Erro ao responder chat:', error);
+    return NextResponse.json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Erro desconhecido ao enviar resposta.',
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/notifications/route.ts
+++ b/src/app/api/admin/notifications/route.ts
@@ -1,0 +1,115 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+interface NotificationRequest {
+  targetType: 'individual' | 'collective';
+  message: string;
+  title?: string;
+  profileId?: string;
+  filters?: {
+    status?: string;
+    is_active?: boolean;
+  };
+  urgency?: 'low' | 'normal' | 'high';
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = (await request.json()) as NotificationRequest;
+    const { targetType, message, profileId, filters, title, urgency } = body;
+
+    if (!targetType || !message) {
+      return NextResponse.json({
+        success: false,
+        error: 'Tipo de envio e mensagem são obrigatórios.',
+      }, { status: 400 });
+    }
+
+    if (targetType === 'individual') {
+      if (!profileId) {
+        return NextResponse.json({
+          success: false,
+          error: 'Selecione um usuário para envio individual.',
+        }, { status: 400 });
+      }
+
+      const payload: Record<string, unknown> = {
+        profile_id: profileId,
+        message,
+      };
+
+      if (title) {
+        payload.title = title;
+      }
+      if (urgency) {
+        payload.urgency = urgency;
+      }
+
+      const { error } = await supabaseAdmin
+        .from('notifications')
+        .insert(payload);
+
+      if (error) {
+        throw new Error(error.message);
+      }
+
+      return NextResponse.json({ success: true, inserted: 1 });
+    }
+
+    let query = supabaseAdmin
+      .from('profiles')
+      .select('id, status, is_active');
+
+    if (filters?.status) {
+      query = query.eq('status', filters.status);
+    }
+    if (typeof filters?.is_active === 'boolean') {
+      query = query.eq('is_active', filters.is_active);
+    }
+
+    const { data: profiles, error: profileError } = await query;
+
+    if (profileError) {
+      throw new Error(profileError.message);
+    }
+
+    if (!profiles || profiles.length === 0) {
+      return NextResponse.json({
+        success: false,
+        error: 'Nenhum usuário encontrado para o filtro informado.',
+      }, { status: 404 });
+    }
+
+    const notifications = profiles.map((profile) => {
+      const payload: Record<string, unknown> = {
+        profile_id: profile.id,
+        message,
+      };
+
+      if (title) {
+        payload.title = title;
+      }
+      if (urgency) {
+        payload.urgency = urgency;
+      }
+
+      return payload;
+    });
+
+    const { error: insertError } = await supabaseAdmin
+      .from('notifications')
+      .insert(notifications);
+
+    if (insertError) {
+      throw new Error(insertError.message);
+    }
+
+    return NextResponse.json({ success: true, inserted: notifications.length });
+  } catch (error) {
+    console.error('Erro ao enviar notificações:', error);
+    return NextResponse.json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Erro desconhecido ao enviar notificações.',
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/registration/overview/route.ts
+++ b/src/app/api/admin/registration/overview/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+interface Totals {
+  active: number;
+  inactive: number;
+  byStatus: Record<string, number>;
+}
+
+export async function GET() {
+  try {
+    const { data: profileData, error: profileError } = await supabaseAdmin
+      .from('profiles')
+      .select('id, name, email, status, is_active, created_at')
+      .order('created_at', { ascending: false })
+      .limit(200);
+
+    if (profileError) {
+      throw new Error(profileError.message);
+    }
+
+    const totals = (profileData ?? []).reduce<Totals>((acc, profile) => {
+      const status = (profile.status || '').toLowerCase();
+      const isActive = profile.is_active ?? (status === 'active');
+
+      if (isActive) {
+        acc.active += 1;
+      } else {
+        acc.inactive += 1;
+      }
+
+      if (status) {
+        acc.byStatus[status] = (acc.byStatus[status] ?? 0) + 1;
+      }
+
+      return acc;
+    }, {
+      active: 0,
+      inactive: 0,
+      byStatus: {},
+    });
+
+    const { data: flows, error: flowsError } = await supabaseAdmin
+      .from('registration_flows')
+      .select('id, profile_id, status, is_active, created_at, updated_at')
+      .order('updated_at', { ascending: false })
+      .limit(50);
+
+    if (flowsError) {
+      throw new Error(flowsError.message);
+    }
+
+    const { data: events, error: eventsError } = await supabaseAdmin
+      .from('registration_flow_events')
+      .select('id, flow_id, event_type, description, created_at')
+      .order('created_at', { ascending: false })
+      .limit(50);
+
+    if (eventsError) {
+      throw new Error(eventsError.message);
+    }
+
+    return NextResponse.json({
+      success: true,
+      totals,
+      profiles: profileData ?? [],
+      flows: flows ?? [],
+      events: events ?? [],
+    });
+  } catch (error) {
+    console.error('Erro ao obter panorama de cadastros:', error);
+    return NextResponse.json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Erro desconhecido ao consultar fluxos de cadastro.',
+    }, { status: 500 });
+  }
+}

--- a/src/app/api/admin/reports/payments/route.ts
+++ b/src/app/api/admin/reports/payments/route.ts
@@ -1,0 +1,86 @@
+import { NextResponse } from 'next/server';
+import { supabaseAdmin } from '@/lib/supabaseAdmin';
+
+interface Movement {
+  id: string;
+  profile_id: string | null;
+  amount: number;
+  status?: string | null;
+  direction?: string | null;
+  created_at: string;
+  reference?: string | null;
+  tx_hash?: string | null;
+}
+
+type MaybeMovementResponse = Movement[] | null;
+
+export async function GET(request: Request) {
+  const { searchParams } = new URL(request.url);
+  const days = Number(searchParams.get('days') ?? '30');
+  const limit = Number(searchParams.get('limit') ?? '100');
+  const since = new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString();
+
+  try {
+    const warnings: string[] = [];
+
+    const { data: pixMovements, error: pixError } = await supabaseAdmin
+      .from('pix_movements')
+      .select('id, profile_id, amount, status, direction, created_at, reference')
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    let pix: MaybeMovementResponse = pixMovements;
+
+    if (pixError) {
+      if ('code' in pixError && pixError.code === 'PGRST116') {
+        warnings.push('Tabela pix_movements não encontrada.');
+        pix = [];
+      } else {
+        throw new Error(pixError.message);
+      }
+    }
+
+    const { data: usdtMovements, error: usdtError } = await supabaseAdmin
+      .from('usdt_movements')
+      .select('id, profile_id, amount, status, direction, created_at, tx_hash')
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(limit);
+
+    let usdt: MaybeMovementResponse = usdtMovements;
+
+    if (usdtError) {
+      if ('code' in usdtError && usdtError.code === 'PGRST116') {
+        warnings.push('Tabela usdt_movements não encontrada.');
+        usdt = [];
+      } else {
+        throw new Error(usdtError.message);
+      }
+    }
+
+    const safePix = Array.isArray(pix) ? pix : [];
+    const safeUsdt = Array.isArray(usdt) ? usdt : [];
+
+    const pixTotal = safePix.reduce((acc, mov) => acc + (mov.amount ?? 0), 0);
+    const usdtTotal = safeUsdt.reduce((acc, mov) => acc + (mov.amount ?? 0), 0);
+
+    return NextResponse.json({
+      success: true,
+      warnings,
+      totals: {
+        pix: pixTotal,
+        usdt: usdtTotal,
+        combined: pixTotal + usdtTotal,
+      },
+      pix: safePix,
+      usdt: safeUsdt,
+    });
+  } catch (error) {
+    console.error('Erro ao gerar relatório de pagamentos:', error);
+    return NextResponse.json({
+      success: false,
+      error: error instanceof Error ? error.message : 'Erro desconhecido ao gerar relatório.',
+    }, { status: 500 });
+  }
+}

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -1,0 +1,46 @@
+'use client';
+
+import { useMemo } from 'react';
+import { createBrowserClient } from '@supabase/ssr';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import FunctionTestRunner from '@/components/Admin/FunctionTestRunner';
+import AdminTableViewer from '@/components/Admin/AdminTableViewer';
+import UserManager from '@/components/Admin/UserManager';
+import NotificationCenter from '@/components/Admin/NotificationCenter';
+import ChatSupportConsole from '@/components/Admin/ChatSupportConsole';
+import PaymentReports from '@/components/Admin/PaymentReports';
+import RegistrationOverview from '@/components/Admin/RegistrationOverview';
+
+export default function DashboardPage() {
+  const supabase = useMemo<SupabaseClient>(() =>
+    createBrowserClient(
+      process.env.NEXT_PUBLIC_SUPABASE_URL!,
+      process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+    ),
+  []);
+
+  return (
+    <div className="min-h-screen bg-gray-950 text-white">
+      <div className="mx-auto w-full max-w-7xl px-4 py-10 space-y-8">
+        <header className="space-y-2">
+          <h1 className="text-3xl font-bold">Painel Administrativo</h1>
+          <p className="text-sm text-gray-400 max-w-3xl">
+            Centralize o acompanhamento das operações da plataforma RENDA MAIS. Consulte tabelas, monitore cadastros, envie
+            notificações e administre o suporte em tempo real.
+          </p>
+        </header>
+
+        <FunctionTestRunner />
+        <RegistrationOverview />
+        <div className="grid grid-cols-1 xl:grid-cols-2 gap-8">
+          <UserManager supabase={supabase} />
+          <NotificationCenter supabase={supabase} />
+        </div>
+        <PaymentReports />
+        <ChatSupportConsole />
+        <AdminTableViewer supabase={supabase} />
+      </div>
+    </div>
+  );
+}

--- a/src/components/Admin/AdminTableViewer.tsx
+++ b/src/components/Admin/AdminTableViewer.tsx
@@ -1,0 +1,187 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface AdminTableViewerProps {
+  supabase: SupabaseClient;
+}
+
+interface TableConfig {
+  name: string;
+  label: string;
+  description?: string;
+}
+
+type RowData = Record<string, unknown>;
+
+const TABLES: TableConfig[] = [
+  { name: 'profiles', label: 'Perfis', description: 'Dados cadastrais dos usuários.' },
+  { name: 'wallets', label: 'Carteiras', description: 'Chaves PIX e endereços de cripto.' },
+  { name: 'donations', label: 'Doações', description: 'Histórico de doações registradas.' },
+  { name: 'donation_events', label: 'Eventos de Doações', description: 'Log detalhado das movimentações de doações.' },
+  { name: 'notifications', label: 'Notificações', description: 'Alertas e mensagens enviadas aos perfis.' },
+  { name: 'chat_threads', label: 'Chats', description: 'Conversas abertas no suporte.' },
+  { name: 'chat_messages', label: 'Mensagens do Chat', description: 'Mensagens trocadas em cada chat.' },
+  { name: 'pix_movements', label: 'Movimentações PIX', description: 'Registros de entradas e saídas via PIX.' },
+  { name: 'usdt_movements', label: 'Movimentações USDT', description: 'Registros de entradas e saídas em USDT.' },
+  { name: 'registration_flows', label: 'Fluxos de Cadastro', description: 'Etapas e status de cadastro.' },
+  { name: 'registration_flow_events', label: 'Eventos do Fluxo', description: 'Histórico de eventos do fluxo de cadastro.' },
+  { name: 'matrix_positions', label: 'Posições de Matriz', description: 'Organização dos perfis nas matrizes.' },
+  { name: 'wallet_logs', label: 'Logs de Carteiras', description: 'Histórico de alterações em carteiras.' },
+];
+
+export default function AdminTableViewer({ supabase }: AdminTableViewerProps) {
+  const [selectedTable, setSelectedTable] = useState<TableConfig>(TABLES[0]);
+  const [data, setData] = useState<RowData[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [limit, setLimit] = useState(50);
+
+  const columns = useMemo(() => {
+    if (!data.length) return [];
+    const columnSet = new Set<string>();
+    data.forEach((row) => {
+      Object.keys(row).forEach((key) => columnSet.add(key));
+    });
+    return Array.from(columnSet);
+  }, [data]);
+
+  const fetchData = useCallback(async (table: TableConfig, rowLimit: number) => {
+    setLoading(true);
+    setError(null);
+    try {
+      const { data: tableData, error: tableError } = await supabase
+        .from(table.name)
+        .select('*')
+        .limit(rowLimit);
+
+      if (tableError) {
+        throw new Error(tableError.message);
+      }
+
+      setData(tableData ?? []);
+    } catch (err) {
+      console.error('Erro ao carregar tabela:', err);
+      setData([]);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao carregar tabela.');
+    } finally {
+      setLoading(false);
+    }
+  }, [supabase]);
+
+  useEffect(() => {
+    fetchData(selectedTable, limit);
+  }, [fetchData, limit, selectedTable]);
+
+  return (
+    <section className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Planilhas e Tabelas</h2>
+          <p className="text-sm text-gray-400">Visualize registros diretamente das tabelas do Supabase.</p>
+        </div>
+        <div className="flex flex-wrap gap-3 items-center">
+          <label className="flex items-center gap-2 text-sm text-gray-300">
+            Limite:
+            <input
+              type="number"
+              min={10}
+              max={500}
+              value={limit}
+              onChange={(event) => setLimit(Number(event.target.value))}
+              className="w-20 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </label>
+          <select
+            value={selectedTable.name}
+            onChange={(event) => {
+              const table = TABLES.find((tbl) => tbl.name === event.target.value);
+              if (table) {
+                setSelectedTable(table);
+              }
+            }}
+            className="rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          >
+            {TABLES.map((table) => (
+              <option key={table.name} value={table.name}>
+                {table.label}
+              </option>
+            ))}
+          </select>
+          <button
+            onClick={() => fetchData(selectedTable, limit)}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500"
+          >
+            Atualizar
+          </button>
+        </div>
+      </div>
+
+      {selectedTable.description && (
+        <p className="mb-4 text-sm text-gray-400">{selectedTable.description}</p>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="overflow-x-auto rounded-lg border border-gray-800">
+        <table className="min-w-full divide-y divide-gray-800">
+          <thead className="bg-gray-800/60">
+            <tr>
+              {columns.map((column) => (
+                <th
+                  key={column}
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-300"
+                >
+                  {column}
+                </th>
+              ))}
+              {!columns.length && (
+                <th className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wider text-gray-300">
+                  Sem dados
+                </th>
+              )}
+            </tr>
+          </thead>
+          <tbody className="divide-y divide-gray-800 bg-gray-900/40">
+            {loading ? (
+              <tr>
+                <td className="px-4 py-6 text-center text-sm text-gray-400" colSpan={columns.length || 1}>
+                  Carregando registros...
+                </td>
+              </tr>
+            ) : data.length ? (
+              data.map((row, index) => (
+                <tr key={index} className="hover:bg-gray-800/50">
+                  {columns.map((column) => {
+                    const value = row[column];
+                    const displayValue = typeof value === 'object' && value !== null
+                      ? JSON.stringify(value)
+                      : value ?? '';
+
+                    return (
+                      <td key={`${column}-${index}`} className="whitespace-nowrap px-4 py-3 text-sm text-gray-200">
+                        {String(displayValue)}
+                      </td>
+                    );
+                  })}
+                </tr>
+              ))
+            ) : (
+              <tr>
+                <td className="px-4 py-6 text-center text-sm text-gray-400" colSpan={columns.length || 1}>
+                  Nenhum registro encontrado para esta tabela.
+                </td>
+              </tr>
+            )}
+          </tbody>
+        </table>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Admin/ChatSupportConsole.tsx
+++ b/src/components/Admin/ChatSupportConsole.tsx
@@ -1,0 +1,231 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type ChatThread = {
+  id: string;
+  profile_id: string;
+  subject?: string | null;
+  status?: string | null;
+  created_at?: string;
+  updated_at?: string | null;
+  unread_count?: number | null;
+};
+
+type ChatMessage = {
+  id: string;
+  thread_id: string;
+  sender_type?: string | null;
+  message: string;
+  created_at?: string;
+};
+
+interface ChatResponse {
+  success: boolean;
+  threads?: ChatThread[];
+  messages?: ChatMessage[];
+  error?: string;
+}
+
+export default function ChatSupportConsole() {
+  const [threads, setThreads] = useState<ChatThread[]>([]);
+  const [selectedThread, setSelectedThread] = useState<ChatThread | null>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [loadingThreads, setLoadingThreads] = useState(false);
+  const [loadingMessages, setLoadingMessages] = useState(false);
+  const [newMessage, setNewMessage] = useState('');
+  const [closeThread, setCloseThread] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchThreads = useCallback(async () => {
+    setLoadingThreads(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/admin/chat');
+      const data = (await response.json()) as ChatResponse;
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Não foi possível carregar os chats.');
+      }
+      setThreads(data.threads ?? []);
+    } catch (err) {
+      console.error('Erro ao carregar threads:', err);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao carregar chats.');
+    } finally {
+      setLoadingThreads(false);
+    }
+  }, []);
+
+  const fetchMessages = useCallback(async (threadId: string) => {
+    setLoadingMessages(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/admin/chat?threadId=${threadId}`);
+      const data = (await response.json()) as ChatResponse;
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Não foi possível carregar mensagens.');
+      }
+      setMessages(data.messages ?? []);
+    } catch (err) {
+      console.error('Erro ao carregar mensagens:', err);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao carregar mensagens.');
+    } finally {
+      setLoadingMessages(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchThreads();
+  }, [fetchThreads]);
+
+  useEffect(() => {
+    if (selectedThread) {
+      fetchMessages(selectedThread.id);
+    } else {
+      setMessages([]);
+    }
+  }, [fetchMessages, selectedThread]);
+
+  const handleSelectThread = (thread: ChatThread) => {
+    setSelectedThread(thread);
+  };
+
+  const handleSendMessage = async () => {
+    if (!selectedThread || !newMessage.trim()) {
+      return;
+    }
+
+    try {
+      const response = await fetch('/api/admin/chat', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          threadId: selectedThread.id,
+          message: newMessage.trim(),
+          closeThread,
+        }),
+      });
+
+      const data = (await response.json()) as ChatResponse;
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Não foi possível enviar a mensagem.');
+      }
+
+      setNewMessage('');
+      setCloseThread(false);
+      await fetchMessages(selectedThread.id);
+      await fetchThreads();
+    } catch (err) {
+      console.error('Erro ao enviar mensagem:', err);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao enviar mensagem.');
+    }
+  };
+
+  return (
+    <section className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-white">Atendimento do Chat</h2>
+        <p className="text-sm text-gray-400">Gerencie conversas abertas e responda diretamente aos usuários da plataforma.</p>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        <div className="lg:col-span-1">
+          <div className="flex items-center justify-between mb-3">
+            <h3 className="text-lg font-medium text-white">Conversas</h3>
+            <button
+              onClick={fetchThreads}
+              className="text-xs font-medium text-emerald-400 hover:text-emerald-300"
+              disabled={loadingThreads}
+            >
+              {loadingThreads ? 'Atualizando...' : 'Atualizar'}
+            </button>
+          </div>
+          <div className="space-y-3 max-h-96 overflow-y-auto pr-2">
+            {threads.map((thread) => (
+              <button
+                key={thread.id}
+                onClick={() => handleSelectThread(thread)}
+                className={`w-full text-left rounded-lg border px-4 py-3 text-sm transition ${selectedThread?.id === thread.id ? 'border-emerald-600 bg-emerald-900/30 text-emerald-100' : 'border-gray-800 bg-gray-800/40 text-gray-200 hover:border-emerald-600 hover:text-white'}`}
+              >
+                <p className="font-medium">{thread.subject || 'Chat sem assunto'}</p>
+                <p className="text-xs text-gray-400">Perfil: {thread.profile_id}</p>
+                <div className="mt-2 flex items-center gap-2 text-xs text-gray-400">
+                  {thread.status && <span className="rounded bg-gray-800 px-2 py-1">{thread.status}</span>}
+                  {typeof thread.unread_count === 'number' && thread.unread_count > 0 && (
+                    <span className="rounded bg-emerald-900/60 px-2 py-1 text-emerald-200">{thread.unread_count} pendente(s)</span>
+                  )}
+                </div>
+              </button>
+            ))}
+            {!threads.length && (
+              <p className="text-sm text-gray-500">Nenhuma conversa encontrada.</p>
+            )}
+          </div>
+        </div>
+
+        <div className="lg:col-span-2">
+          <h3 className="text-lg font-medium text-white mb-3">Mensagens</h3>
+          <div className="rounded-lg border border-gray-800 bg-gray-900/40 h-80 overflow-y-auto p-4 space-y-3">
+            {loadingMessages ? (
+              <p className="text-sm text-gray-500">Carregando mensagens...</p>
+            ) : messages.length ? (
+              messages.map((message) => (
+                <div
+                  key={message.id}
+                  className={`rounded-lg px-4 py-3 text-sm ${message.sender_type === 'admin' ? 'bg-emerald-900/40 border border-emerald-700 text-emerald-100 ml-auto max-w-[80%]' : 'bg-gray-800/60 border border-gray-700 text-gray-200 max-w-[80%]'}`}
+                >
+                  <p className="mb-1 text-xs uppercase tracking-wide text-gray-400">
+                    {message.sender_type === 'admin' ? 'Admin' : message.sender_type || 'Usuário'}
+                  </p>
+                  <p>{message.message}</p>
+                  {message.created_at && (
+                    <p className="mt-2 text-[10px] uppercase text-gray-500">
+                      {new Date(message.created_at).toLocaleString()}
+                    </p>
+                  )}
+                </div>
+              ))
+            ) : (
+              <p className="text-sm text-gray-500">Selecione uma conversa para visualizar as mensagens.</p>
+            )}
+          </div>
+
+          <div className="mt-4 space-y-3">
+            <textarea
+              value={newMessage}
+              onChange={(event) => setNewMessage(event.target.value)}
+              rows={3}
+              placeholder="Escreva sua resposta"
+              className="w-full rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+            <div className="flex flex-wrap items-center justify-between gap-3">
+              <label className="inline-flex items-center gap-2 text-sm text-gray-300">
+                <input
+                  type="checkbox"
+                  checked={closeThread}
+                  onChange={(event) => setCloseThread(event.target.checked)}
+                  className="h-4 w-4 rounded border-gray-700 bg-gray-800 text-emerald-600 focus:ring-emerald-500"
+                />
+                Encerrar conversa após responder
+              </label>
+              <button
+                onClick={handleSendMessage}
+                disabled={!selectedThread || !newMessage.trim()}
+                className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                Enviar resposta
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Admin/FunctionTestRunner.tsx
+++ b/src/components/Admin/FunctionTestRunner.tsx
@@ -1,0 +1,131 @@
+'use client';
+
+import { useState } from 'react';
+
+type TestFunctionResult = {
+  function: string;
+  success: boolean;
+  error?: string;
+  result?: unknown;
+  count?: number;
+  code?: string;
+};
+
+type TestTableResult = {
+  table: string;
+  success: boolean;
+  error?: string;
+  count?: number;
+};
+
+interface TestResponse {
+  success: boolean;
+  message: string;
+  functions: TestFunctionResult[];
+  tables: TestTableResult[];
+}
+
+export default function FunctionTestRunner() {
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<TestResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const runTests = async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch('/api/setup/test-functions', {
+        method: 'POST',
+      });
+      if (!response.ok) {
+        throw new Error('Falha ao executar testes.');
+      }
+      const data = (await response.json()) as TestResponse;
+      setResults(data);
+    } catch (err) {
+      console.error('Erro ao executar testes:', err);
+      setResults(null);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao executar testes.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <section className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-4">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Testes de Funcionamento</h2>
+          <p className="text-sm text-gray-400">Execute verificações das funções SQL essenciais e das tabelas base.</p>
+        </div>
+        <button
+          onClick={runTests}
+          disabled={loading}
+          className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+        >
+          {loading ? 'Executando...' : 'Rodar testes' }
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      {results && (
+        <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+          <div>
+            <h3 className="text-lg font-medium text-white mb-3">Funções SQL</h3>
+            <div className="space-y-3">
+              {results.functions.map((item) => (
+                <div
+                  key={item.function}
+                  className={`rounded-lg border px-4 py-3 text-sm ${item.success ? 'border-emerald-700 bg-emerald-900/20 text-emerald-200' : 'border-red-700 bg-red-900/20 text-red-200'}`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">{item.function}</span>
+                    <span className="text-xs uppercase tracking-wide">{item.success ? 'OK' : 'Erro'}</span>
+                  </div>
+                  {!item.success && item.error && (
+                    <p className="mt-2 text-xs text-red-200/80">{item.error}</p>
+                  )}
+                  {item.success && typeof item.count === 'number' && (
+                    <p className="mt-2 text-xs text-emerald-200/80">Registros: {item.count}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium text-white mb-3">Tabelas Monitoradas</h3>
+            <div className="space-y-3">
+              {results.tables.map((item) => (
+                <div
+                  key={item.table}
+                  className={`rounded-lg border px-4 py-3 text-sm ${item.success ? 'border-emerald-700 bg-emerald-900/20 text-emerald-200' : 'border-red-700 bg-red-900/20 text-red-200'}`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="font-medium">{item.table}</span>
+                    <span className="text-xs uppercase tracking-wide">{item.success ? 'OK' : 'Erro'}</span>
+                  </div>
+                  {!item.success && item.error && (
+                    <p className="mt-2 text-xs text-red-200/80">{item.error}</p>
+                  )}
+                  {item.success && typeof item.count === 'number' && (
+                    <p className="mt-2 text-xs text-emerald-200/80">Registros: {item.count}</p>
+                  )}
+                </div>
+              ))}
+            </div>
+          </div>
+        </div>
+      )}
+
+      {!loading && !results && !error && (
+        <p className="text-sm text-gray-500">Clique em &quot;Rodar testes&quot; para verificar o status das funções.</p>
+      )}
+    </section>
+  );
+}

--- a/src/components/Admin/NotificationCenter.tsx
+++ b/src/components/Admin/NotificationCenter.tsx
@@ -1,0 +1,349 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+interface NotificationCenterProps {
+  supabase: SupabaseClient;
+}
+
+type Recipient = {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  username?: string | null;
+};
+
+type NotificationTarget = 'individual' | 'collective';
+
+type NotificationResponse = {
+  success: boolean;
+  inserted?: number;
+  error?: string;
+};
+
+export default function NotificationCenter({ supabase }: NotificationCenterProps) {
+  const [target, setTarget] = useState<NotificationTarget>('individual');
+  const [recipientQuery, setRecipientQuery] = useState('');
+  const [selectedRecipient, setSelectedRecipient] = useState<Recipient | null>(null);
+  const [title, setTitle] = useState('');
+  const [message, setMessage] = useState('');
+  const [urgency, setUrgency] = useState<'low' | 'normal' | 'high'>('normal');
+  const [statusFilter, setStatusFilter] = useState('active');
+  const [sending, setSending] = useState(false);
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const [alertTitle, setAlertTitle] = useState('');
+  const [alertMessage, setAlertMessage] = useState('');
+  const [alertSeverity, setAlertSeverity] = useState<'info' | 'warning' | 'critical'>('info');
+  const [creatingAlert, setCreatingAlert] = useState(false);
+
+  const findRecipient = useCallback(async () => {
+    if (!recipientQuery.trim()) {
+      setError('Informe e-mail, usuário ou nome para localizar o destinatário.');
+      return;
+    }
+
+    setError(null);
+    setFeedback(null);
+
+    try {
+      const { data, error: supabaseError } = await supabase
+        .from('profiles')
+        .select('id, name, email, username')
+        .or(`email.ilike.%${recipientQuery.trim()}%,username.ilike.%${recipientQuery.trim()}%,name.ilike.%${recipientQuery.trim()}%`)
+        .limit(1)
+        .maybeSingle();
+
+      if (supabaseError) {
+        throw new Error(supabaseError.message);
+      }
+
+      if (!data) {
+        setSelectedRecipient(null);
+        setError('Usuário não encontrado. Verifique o identificador informado.');
+        return;
+      }
+
+      setSelectedRecipient(data);
+      setFeedback(`Destinatário selecionado: ${data.name || data.username || data.email}`);
+    } catch (err) {
+      console.error('Erro ao localizar destinatário:', err);
+      setSelectedRecipient(null);
+      setFeedback(null);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao buscar usuário.');
+    }
+  }, [recipientQuery, supabase]);
+
+  const sendNotification = useCallback(async () => {
+    if (!message.trim()) {
+      setError('Informe uma mensagem para enviar.');
+      return;
+    }
+
+    if (target === 'individual' && !selectedRecipient) {
+      setError('Selecione um destinatário para o envio individual.');
+      return;
+    }
+
+    setSending(true);
+    setError(null);
+    setFeedback(null);
+
+    try {
+      const response = await fetch('/api/admin/notifications', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          targetType: target,
+          profileId: selectedRecipient?.id,
+          title: title.trim() || undefined,
+          message: message.trim(),
+          urgency,
+          filters: target === 'collective' ? { status: statusFilter } : undefined,
+        }),
+      });
+
+      const data = (await response.json()) as NotificationResponse;
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Falha ao enviar notificações.');
+      }
+
+      setFeedback(`Notificação enviada com sucesso${data.inserted ? ` para ${data.inserted} destinatário(s)` : ''}.`);
+      setMessage('');
+      setTitle('');
+    } catch (err) {
+      console.error('Erro ao enviar notificação:', err);
+      setFeedback(null);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao enviar notificação.');
+    } finally {
+      setSending(false);
+    }
+  }, [message, selectedRecipient, statusFilter, target, title, urgency]);
+
+  const createAlert = useCallback(async () => {
+    if (!alertTitle.trim() || !alertMessage.trim()) {
+      setError('Informe título e mensagem do alerta.');
+      return;
+    }
+
+    setCreatingAlert(true);
+    setError(null);
+    setFeedback(null);
+
+    try {
+      const response = await fetch('/api/admin/alerts', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          title: alertTitle.trim(),
+          message: alertMessage.trim(),
+          severity: alertSeverity,
+        }),
+      });
+
+      const data = (await response.json()) as NotificationResponse;
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Falha ao criar alerta.');
+      }
+
+      setFeedback('Alerta registrado com sucesso.');
+      setAlertTitle('');
+      setAlertMessage('');
+    } catch (err) {
+      console.error('Erro ao criar alerta:', err);
+      setFeedback(null);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao criar alerta.');
+    } finally {
+      setCreatingAlert(false);
+    }
+  }, [alertMessage, alertSeverity, alertTitle]);
+
+  return (
+    <section className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-white">Alertas & Notificações</h2>
+        <p className="text-sm text-gray-400">Envie avisos individuais ou coletivos e registre alertas da plataforma.</p>
+      </div>
+
+      {feedback && (
+        <div className="mb-4 rounded-md border border-emerald-700 bg-emerald-900/20 px-4 py-3 text-sm text-emerald-200">
+          {feedback}
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-8">
+        <div>
+          <h3 className="text-lg font-medium text-white mb-4">Envio de notificações</h3>
+          <div className="space-y-4">
+            <div className="flex flex-wrap gap-3">
+              <label className="inline-flex items-center gap-2 text-sm text-gray-300">
+                <input
+                  type="radio"
+                  value="individual"
+                  checked={target === 'individual'}
+                  onChange={() => setTarget('individual')}
+                  className="h-4 w-4 text-emerald-600 focus:ring-emerald-500"
+                />
+                Individual
+              </label>
+              <label className="inline-flex items-center gap-2 text-sm text-gray-300">
+                <input
+                  type="radio"
+                  value="collective"
+                  checked={target === 'collective'}
+                  onChange={() => setTarget('collective')}
+                  className="h-4 w-4 text-emerald-600 focus:ring-emerald-500"
+                />
+                Coletiva
+              </label>
+            </div>
+
+            {target === 'individual' ? (
+              <div className="space-y-2">
+                <div className="flex gap-2">
+                  <input
+                    type="text"
+                    value={recipientQuery}
+                    onChange={(event) => setRecipientQuery(event.target.value)}
+                    placeholder="Buscar por e-mail, usuário ou nome"
+                    className="flex-1 rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                  />
+                  <button
+                    onClick={findRecipient}
+                    className="rounded-md bg-slate-700 px-4 py-2 text-sm font-medium text-white hover:bg-slate-600"
+                  >
+                    Localizar
+                  </button>
+                </div>
+                {selectedRecipient ? (
+                  <p className="text-xs text-emerald-300">{selectedRecipient.name || selectedRecipient.username || selectedRecipient.email}</p>
+                ) : (
+                  <p className="text-xs text-gray-500">Nenhum destinatário selecionado.</p>
+                )}
+              </div>
+            ) : (
+              <div className="space-y-2">
+                <label className="block text-sm font-medium text-gray-300">Filtrar por status</label>
+                <select
+                  value={statusFilter}
+                  onChange={(event) => setStatusFilter(event.target.value)}
+                  className="w-full rounded-md border border-gray-700 bg-gray-800 px-3 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                >
+                  <option value="active">Ativos</option>
+                  <option value="inactive">Inativos</option>
+                  <option value="pending">Pendentes</option>
+                  <option value="">Todos</option>
+                </select>
+              </div>
+            )}
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Título (opcional)</label>
+              <input
+                type="text"
+                value={title}
+                onChange={(event) => setTitle(event.target.value)}
+                placeholder="Resumo da mensagem"
+                className="w-full rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Mensagem</label>
+              <textarea
+                value={message}
+                onChange={(event) => setMessage(event.target.value)}
+                rows={4}
+                placeholder="Conteúdo da notificação"
+                className="w-full rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+
+            <div className="flex flex-wrap items-center gap-4">
+              <label className="text-sm text-gray-300">
+                Urgência:
+                <select
+                  value={urgency}
+                  onChange={(event) => setUrgency(event.target.value as typeof urgency)}
+                  className="ml-2 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                >
+                  <option value="low">Baixa</option>
+                  <option value="normal">Normal</option>
+                  <option value="high">Alta</option>
+                </select>
+              </label>
+              <button
+                onClick={sendNotification}
+                disabled={sending}
+                className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {sending ? 'Enviando...' : 'Enviar notificação'}
+              </button>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-lg font-medium text-white mb-4">Registro de alertas</h3>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Título</label>
+              <input
+                type="text"
+                value={alertTitle}
+                onChange={(event) => setAlertTitle(event.target.value)}
+                placeholder="Título do alerta"
+                className="w-full rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-300 mb-1">Mensagem</label>
+              <textarea
+                value={alertMessage}
+                onChange={(event) => setAlertMessage(event.target.value)}
+                rows={4}
+                placeholder="Descreva o alerta ou incidente"
+                className="w-full rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+              />
+            </div>
+            <div className="flex flex-wrap items-center gap-4">
+              <label className="text-sm text-gray-300">
+                Severidade:
+                <select
+                  value={alertSeverity}
+                  onChange={(event) => setAlertSeverity(event.target.value as typeof alertSeverity)}
+                  className="ml-2 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                >
+                  <option value="info">Informativo</option>
+                  <option value="warning">Atenção</option>
+                  <option value="critical">Crítico</option>
+                </select>
+              </label>
+              <button
+                onClick={createAlert}
+                disabled={creatingAlert}
+                className="rounded-md bg-slate-700 px-4 py-2 text-sm font-medium text-white hover:bg-slate-600 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {creatingAlert ? 'Registrando...' : 'Registrar alerta'}
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Admin/PaymentReports.tsx
+++ b/src/components/Admin/PaymentReports.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+type Movement = {
+  id: string;
+  profile_id: string | null;
+  amount: number;
+  status?: string | null;
+  direction?: string | null;
+  created_at: string;
+  reference?: string | null;
+  tx_hash?: string | null;
+};
+
+type PaymentReportResponse = {
+  success: boolean;
+  totals?: {
+    pix: number;
+    usdt: number;
+    combined: number;
+  };
+  warnings?: string[];
+  pix?: Movement[];
+  usdt?: Movement[];
+  error?: string;
+};
+
+const formatCurrency = (value: number, currency: 'BRL' | 'USD') =>
+  new Intl.NumberFormat('pt-BR', {
+    style: 'currency',
+    currency,
+    minimumFractionDigits: 2,
+  }).format(value || 0);
+
+export default function PaymentReports() {
+  const [days, setDays] = useState(30);
+  const [limit, setLimit] = useState(100);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [warnings, setWarnings] = useState<string[]>([]);
+  const [pixMovements, setPixMovements] = useState<Movement[]>([]);
+  const [usdtMovements, setUsdtMovements] = useState<Movement[]>([]);
+  const [totals, setTotals] = useState<{ pix: number; usdt: number; combined: number }>({ pix: 0, usdt: 0, combined: 0 });
+
+  const fetchReports = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetch(`/api/admin/reports/payments?days=${days}&limit=${limit}`);
+      const data = (await response.json()) as PaymentReportResponse;
+
+      if (!response.ok || !data.success) {
+        throw new Error(data.error || 'Não foi possível gerar o relatório.');
+      }
+
+      setPixMovements(data.pix ?? []);
+      setUsdtMovements(data.usdt ?? []);
+      setWarnings(data.warnings ?? []);
+      setTotals(data.totals ?? { pix: 0, usdt: 0, combined: 0 });
+    } catch (err) {
+      console.error('Erro ao carregar relatório:', err);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao consultar relatório.');
+      setPixMovements([]);
+      setUsdtMovements([]);
+      setTotals({ pix: 0, usdt: 0, combined: 0 });
+    } finally {
+      setLoading(false);
+    }
+  }, [days, limit]);
+
+  useEffect(() => {
+    fetchReports();
+  }, [fetchReports]);
+
+  return (
+    <section className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Relatórios de PIX &amp; USDT</h2>
+          <p className="text-sm text-gray-400">Acompanhe movimentações recentes e o total consolidado por método de pagamento.</p>
+        </div>
+        <div className="flex flex-wrap gap-3 items-center">
+          <label className="text-sm text-gray-300 flex items-center gap-2">
+            Dias:
+            <input
+              type="number"
+              min={1}
+              max={180}
+              value={days}
+              onChange={(event) => setDays(Number(event.target.value))}
+              className="w-20 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </label>
+          <label className="text-sm text-gray-300 flex items-center gap-2">
+            Limite:
+            <input
+              type="number"
+              min={10}
+              max={500}
+              value={limit}
+              onChange={(event) => setLimit(Number(event.target.value))}
+              className="w-20 rounded-md border border-gray-700 bg-gray-800 px-2 py-1 text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+            />
+          </label>
+          <button
+            onClick={fetchReports}
+            disabled={loading}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? 'Atualizando...' : 'Atualizar'}
+          </button>
+        </div>
+      </div>
+
+      {warnings.length > 0 && (
+        <div className="mb-4 space-y-2">
+          {warnings.map((warning) => (
+            <div key={warning} className="rounded-md border border-yellow-600 bg-yellow-900/20 px-4 py-3 text-sm text-yellow-200">
+              {warning}
+            </div>
+          ))}
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div className="rounded-lg border border-gray-800 bg-gray-800/40 p-4">
+          <h3 className="text-sm text-gray-400">Total PIX</h3>
+          <p className="mt-2 text-2xl font-semibold text-emerald-300">{formatCurrency(totals.pix, 'BRL')}</p>
+        </div>
+        <div className="rounded-lg border border-gray-800 bg-gray-800/40 p-4">
+          <h3 className="text-sm text-gray-400">Total USDT</h3>
+          <p className="mt-2 text-2xl font-semibold text-emerald-300">{formatCurrency(totals.usdt, 'USD')}</p>
+        </div>
+        <div className="rounded-lg border border-gray-800 bg-gray-800/40 p-4">
+          <h3 className="text-sm text-gray-400">Total Geral (conversão simples)</h3>
+          <p className="mt-2 text-2xl font-semibold text-emerald-300">{formatCurrency(totals.combined, 'BRL')}</p>
+          <p className="mt-1 text-xs text-gray-500">*Considerando PIX em BRL e USDT convertido 1:1.</p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <h3 className="text-lg font-medium text-white mb-3">Movimentações PIX</h3>
+          <div className="max-h-80 overflow-y-auto rounded-lg border border-gray-800">
+            <table className="min-w-full divide-y divide-gray-800">
+              <thead className="bg-gray-800/60">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Perfil</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Valor</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Status</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Direção</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Criado em</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-800 bg-gray-900/40">
+                {pixMovements.length ? (
+                  pixMovements.map((movement) => (
+                    <tr key={movement.id}>
+                      <td className="px-4 py-2 text-sm text-gray-200">{movement.profile_id ?? 'N/D'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-200">{formatCurrency(movement.amount, 'BRL')}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{movement.status ?? '—'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{movement.direction ?? '—'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{new Date(movement.created_at).toLocaleString()}</td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td className="px-4 py-4 text-center text-sm text-gray-500" colSpan={5}>
+                      Nenhuma movimentação encontrada.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-lg font-medium text-white mb-3">Movimentações USDT</h3>
+          <div className="max-h-80 overflow-y-auto rounded-lg border border-gray-800">
+            <table className="min-w-full divide-y divide-gray-800">
+              <thead className="bg-gray-800/60">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Perfil</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Valor</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Status</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Direção</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Referência</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Criado em</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-800 bg-gray-900/40">
+                {usdtMovements.length ? (
+                  usdtMovements.map((movement) => (
+                    <tr key={movement.id}>
+                      <td className="px-4 py-2 text-sm text-gray-200">{movement.profile_id ?? 'N/D'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-200">{formatCurrency(movement.amount, 'USD')}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{movement.status ?? '—'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{movement.direction ?? '—'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{movement.tx_hash ?? movement.reference ?? '—'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{new Date(movement.created_at).toLocaleString()}</td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td className="px-4 py-4 text-center text-sm text-gray-500" colSpan={6}>
+                      Nenhuma movimentação encontrada.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Admin/RegistrationOverview.tsx
+++ b/src/components/Admin/RegistrationOverview.tsx
@@ -1,0 +1,199 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+
+type ProfileSummary = {
+  id: string;
+  name?: string | null;
+  email?: string | null;
+  status?: string | null;
+  is_active?: boolean | null;
+  created_at: string;
+};
+
+type RegistrationFlow = {
+  id: string;
+  profile_id: string;
+  status?: string | null;
+  is_active?: boolean | null;
+  created_at: string;
+  updated_at?: string | null;
+};
+
+type RegistrationEvent = {
+  id: string;
+  flow_id: string;
+  event_type?: string | null;
+  description?: string | null;
+  created_at: string;
+};
+
+type RegistrationOverviewResponse = {
+  success: boolean;
+  totals?: {
+    active: number;
+    inactive: number;
+    byStatus: Record<string, number>;
+  };
+  profiles?: ProfileSummary[];
+  flows?: RegistrationFlow[];
+  events?: RegistrationEvent[];
+  error?: string;
+};
+
+export default function RegistrationOverview() {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [totals, setTotals] = useState<{ active: number; inactive: number; byStatus: Record<string, number> }>({
+    active: 0,
+    inactive: 0,
+    byStatus: {},
+  });
+  const [profiles, setProfiles] = useState<ProfileSummary[]>([]);
+  const [flows, setFlows] = useState<RegistrationFlow[]>([]);
+  const [events, setEvents] = useState<RegistrationEvent[]>([]);
+
+  useEffect(() => {
+    const fetchOverview = async () => {
+      setLoading(true);
+      setError(null);
+      try {
+        const response = await fetch('/api/admin/registration/overview');
+        const data = (await response.json()) as RegistrationOverviewResponse;
+        if (!response.ok || !data.success) {
+          throw new Error(data.error || 'Não foi possível obter o panorama de cadastros.');
+        }
+        setTotals(data.totals ?? { active: 0, inactive: 0, byStatus: {} });
+        setProfiles(data.profiles ?? []);
+        setFlows(data.flows ?? []);
+        setEvents(data.events ?? []);
+      } catch (err) {
+        console.error('Erro ao carregar panorama de cadastros:', err);
+        setError(err instanceof Error ? err.message : 'Erro desconhecido ao carregar dados de cadastro.');
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchOverview();
+  }, []);
+
+  const statusEntries = Object.entries(totals.byStatus);
+
+  return (
+    <section className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+      <div className="mb-6">
+        <h2 className="text-xl font-semibold text-white">Fluxo de Cadastros</h2>
+        <p className="text-sm text-gray-400">Visualize o volume de cadastros ativos e inativos, além das últimas movimentações de fluxo.</p>
+      </div>
+
+      {loading && (
+        <div className="mb-4 rounded-md border border-emerald-700 bg-emerald-900/20 px-4 py-3 text-sm text-emerald-200">
+          Carregando panorama de cadastros...
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 md:grid-cols-3 gap-4 mb-6">
+        <div className="rounded-lg border border-gray-800 bg-gray-800/40 p-4">
+          <h3 className="text-sm text-gray-400">Cadastros ativos</h3>
+          <p className="mt-2 text-2xl font-semibold text-emerald-300">{totals.active}</p>
+        </div>
+        <div className="rounded-lg border border-gray-800 bg-gray-800/40 p-4">
+          <h3 className="text-sm text-gray-400">Cadastros inativos</h3>
+          <p className="mt-2 text-2xl font-semibold text-emerald-300">{totals.inactive}</p>
+        </div>
+        <div className="rounded-lg border border-gray-800 bg-gray-800/40 p-4">
+          <h3 className="text-sm text-gray-400">Status detalhado</h3>
+          {statusEntries.length ? (
+            <ul className="mt-2 space-y-1 text-sm text-gray-300">
+              {statusEntries.map(([status, count]) => (
+                <li key={status} className="flex items-center justify-between">
+                  <span className="capitalize">{status}</span>
+                  <span>{count}</span>
+                </li>
+              ))}
+            </ul>
+          ) : (
+            <p className="mt-2 text-sm text-gray-500">Sem dados de status disponíveis.</p>
+          )}
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <h3 className="text-lg font-medium text-white mb-3">Últimos cadastros</h3>
+          <div className="max-h-80 overflow-y-auto rounded-lg border border-gray-800">
+            <table className="min-w-full divide-y divide-gray-800">
+              <thead className="bg-gray-800/60">
+                <tr>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Nome</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">E-mail</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Status</th>
+                  <th className="px-4 py-2 text-left text-xs font-medium uppercase tracking-wider text-gray-300">Criado em</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-gray-800 bg-gray-900/40">
+                {profiles.length ? (
+                  profiles.map((profile) => (
+                    <tr key={profile.id}>
+                      <td className="px-4 py-2 text-sm text-gray-200">{profile.name || '—'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-200">{profile.email || '—'}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{profile.status || (profile.is_active ? 'active' : 'inactive')}</td>
+                      <td className="px-4 py-2 text-sm text-gray-400">{new Date(profile.created_at).toLocaleString()}</td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td className="px-4 py-4 text-center text-sm text-gray-500" colSpan={4}>
+                      Nenhum cadastro encontrado.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+
+        <div className="space-y-6">
+          <div>
+            <h3 className="text-lg font-medium text-white mb-3">Fluxos recentes</h3>
+            <div className="max-h-36 overflow-y-auto rounded-lg border border-gray-800 bg-gray-900/40 divide-y divide-gray-800">
+              {flows.length ? flows.map((flow) => (
+                <div key={flow.id} className="px-4 py-3 text-sm text-gray-200">
+                  <p className="font-medium">Fluxo #{flow.id}</p>
+                  <p className="text-xs text-gray-400">Perfil: {flow.profile_id}</p>
+                  <p className="text-xs text-gray-400">Status: {flow.status || (flow.is_active ? 'active' : 'inactive')}</p>
+                  <p className="text-xs text-gray-500 mt-1">Atualizado em {flow.updated_at ? new Date(flow.updated_at).toLocaleString() : '—'}</p>
+                </div>
+              )) : (
+                <p className="px-4 py-3 text-sm text-gray-500">Nenhum fluxo recente encontrado.</p>
+              )}
+            </div>
+          </div>
+
+          <div>
+            <h3 className="text-lg font-medium text-white mb-3">Eventos do fluxo</h3>
+            <div className="max-h-36 overflow-y-auto rounded-lg border border-gray-800 bg-gray-900/40 divide-y divide-gray-800">
+              {events.length ? events.map((event) => (
+                <div key={event.id} className="px-4 py-3 text-sm text-gray-200">
+                  <p className="font-medium">Evento {event.event_type || event.id}</p>
+                  <p className="text-xs text-gray-400">Flow: {event.flow_id}</p>
+                  {event.description && <p className="text-xs text-gray-400">{event.description}</p>}
+                  <p className="text-xs text-gray-500 mt-1">{new Date(event.created_at).toLocaleString()}</p>
+                </div>
+              )) : (
+                <p className="px-4 py-3 text-sm text-gray-500">Nenhum evento recente registrado.</p>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/components/Admin/UserManager.tsx
+++ b/src/components/Admin/UserManager.tsx
@@ -1,0 +1,233 @@
+'use client';
+
+import { useCallback, useMemo, useState } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+interface UserManagerProps {
+  supabase: SupabaseClient;
+}
+
+type ProfileRecord = {
+  id: string;
+  name?: string | null;
+  username?: string | null;
+  email?: string | null;
+  whatsapp?: string | null;
+  country?: string | null;
+  status?: string | null;
+  is_active?: boolean | null;
+  created_at?: string;
+  [key: string]: unknown;
+};
+
+const EDITABLE_FIELDS: { key: keyof ProfileRecord; label: string; type: 'text' | 'email' | 'tel' | 'boolean'; placeholder?: string }[] = [
+  { key: 'name', label: 'Nome completo', type: 'text', placeholder: 'Nome do usuário' },
+  { key: 'username', label: 'Usuário', type: 'text', placeholder: 'Identificador interno' },
+  { key: 'email', label: 'E-mail', type: 'email', placeholder: 'email@exemplo.com' },
+  { key: 'whatsapp', label: 'WhatsApp', type: 'tel', placeholder: 'Número com DDD' },
+  { key: 'country', label: 'País', type: 'text', placeholder: 'País' },
+  { key: 'status', label: 'Status', type: 'text', placeholder: 'active | inactive | pending' },
+  { key: 'is_active', label: 'Ativo', type: 'boolean' },
+];
+
+export default function UserManager({ supabase }: UserManagerProps) {
+  const [searchTerm, setSearchTerm] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [results, setResults] = useState<ProfileRecord[]>([]);
+  const [selectedProfile, setSelectedProfile] = useState<ProfileRecord | null>(null);
+  const [formState, setFormState] = useState<Record<string, unknown>>({});
+  const [feedback, setFeedback] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSearch = useCallback(async () => {
+    if (!searchTerm.trim()) {
+      setFeedback('Informe nome, e-mail ou WhatsApp para pesquisar.');
+      return;
+    }
+
+    setLoading(true);
+    setFeedback(null);
+    setError(null);
+
+    try {
+      const { data, error: supabaseError } = await supabase
+        .from('profiles')
+        .select('*')
+        .or(`email.ilike.%${searchTerm.trim()}%,username.ilike.%${searchTerm.trim()}%,whatsapp.ilike.%${searchTerm.trim()}%`)
+        .limit(20);
+
+      if (supabaseError) {
+        throw new Error(supabaseError.message);
+      }
+
+      setResults(data ?? []);
+      if (!data?.length) {
+        setFeedback('Nenhum perfil encontrado. Ajuste os filtros e tente novamente.');
+      }
+    } catch (err) {
+      console.error('Erro ao pesquisar perfis:', err);
+      setResults([]);
+      setFeedback(null);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao buscar perfis.');
+    } finally {
+      setLoading(false);
+    }
+  }, [searchTerm, supabase]);
+
+  const selectProfile = useCallback((profile: ProfileRecord) => {
+    setSelectedProfile(profile);
+    setFormState(profile);
+    setFeedback(null);
+    setError(null);
+  }, []);
+
+  const handleUpdate = useCallback(async () => {
+    if (!selectedProfile) return;
+
+    setLoading(true);
+    setFeedback(null);
+    setError(null);
+
+    try {
+      const updates: Record<string, unknown> = {};
+      EDITABLE_FIELDS.forEach(({ key }) => {
+        if (key in formState) {
+          updates[key as string] = formState[key];
+        }
+      });
+
+      const { error: updateError } = await supabase
+        .from('profiles')
+        .update(updates)
+        .eq('id', selectedProfile.id);
+
+      if (updateError) {
+        throw new Error(updateError.message);
+      }
+
+      setFeedback('Perfil atualizado com sucesso!');
+      setSelectedProfile((prev) => (prev ? { ...prev, ...updates } : prev));
+    } catch (err) {
+      console.error('Erro ao atualizar perfil:', err);
+      setFeedback(null);
+      setError(err instanceof Error ? err.message : 'Erro desconhecido ao atualizar perfil.');
+    } finally {
+      setLoading(false);
+    }
+  }, [formState, selectedProfile, supabase]);
+
+  const selectedFields = useMemo(() => {
+    if (!selectedProfile) return [];
+    return EDITABLE_FIELDS.filter((field) => field.key in selectedProfile);
+  }, [selectedProfile]);
+
+  return (
+    <section className="bg-gray-900 border border-gray-800 rounded-xl p-6">
+      <div className="flex flex-col md:flex-row md:items-center md:justify-between gap-4 mb-6">
+        <div>
+          <h2 className="text-xl font-semibold text-white">Gestão de Usuários</h2>
+          <p className="text-sm text-gray-400">Pesquise perfis e atualize dados cadastrais diretamente da base.</p>
+        </div>
+        <div className="flex gap-3">
+          <input
+            type="text"
+            value={searchTerm}
+            onChange={(event) => setSearchTerm(event.target.value)}
+            placeholder="Buscar por nome, e-mail ou WhatsApp"
+            className="w-full md:w-80 rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+          />
+          <button
+            onClick={handleSearch}
+            disabled={loading}
+            className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+          >
+            {loading ? 'Buscando...' : 'Pesquisar'}
+          </button>
+        </div>
+      </div>
+
+      {feedback && (
+        <div className="mb-4 rounded-md border border-emerald-700 bg-emerald-900/20 px-4 py-3 text-sm text-emerald-200">
+          {feedback}
+        </div>
+      )}
+
+      {error && (
+        <div className="mb-4 rounded-md border border-red-700 bg-red-900/40 px-4 py-3 text-sm text-red-300">
+          {error}
+        </div>
+      )}
+
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div>
+          <h3 className="text-lg font-medium text-white mb-3">Resultados</h3>
+          <div className="space-y-3 max-h-80 overflow-y-auto pr-2">
+            {results.map((profile) => (
+              <button
+                key={profile.id}
+                onClick={() => selectProfile(profile)}
+                className={`w-full text-left rounded-lg border px-4 py-3 text-sm transition ${selectedProfile?.id === profile.id ? 'border-emerald-600 bg-emerald-900/30 text-emerald-100' : 'border-gray-800 bg-gray-800/40 text-gray-200 hover:border-emerald-600 hover:text-white'}`}
+              >
+                <p className="font-medium">{profile.name || profile.username || 'Usuário sem nome'}</p>
+                <p className="text-xs text-gray-400">{profile.email || 'Sem e-mail'}</p>
+                <div className="mt-2 flex flex-wrap gap-2 text-xs text-gray-400">
+                  {profile.status && <span className="rounded bg-gray-800 px-2 py-1">Status: {profile.status}</span>}
+                  {'is_active' in profile && (
+                    <span className="rounded bg-gray-800 px-2 py-1">{profile.is_active ? 'Ativo' : 'Inativo'}</span>
+                  )}
+                </div>
+              </button>
+            ))}
+            {!results.length && (
+              <p className="text-sm text-gray-500">Realize uma busca para listar usuários.</p>
+            )}
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-lg font-medium text-white mb-3">Editar cadastro</h3>
+          {selectedProfile ? (
+            <div className="space-y-4">
+              {selectedFields.length ? selectedFields.map((field) => (
+                <div key={field.key as string}>
+                  <label className="block text-sm font-medium text-gray-300 mb-1">{field.label}</label>
+                  {field.type === 'boolean' ? (
+                    <div className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        checked={Boolean(formState[field.key])}
+                        onChange={(event) => setFormState((prev) => ({ ...prev, [field.key]: event.target.checked }))}
+                        className="h-4 w-4 rounded border-gray-700 bg-gray-800 text-emerald-600 focus:ring-emerald-500"
+                      />
+                      <span className="text-sm text-gray-300">Ativar usuário</span>
+                    </div>
+                  ) : (
+                    <input
+                      type={field.type}
+                      value={(formState[field.key] as string | number | undefined) ?? ''}
+                      placeholder={field.placeholder}
+                      onChange={(event) => setFormState((prev) => ({ ...prev, [field.key]: event.target.value }))}
+                      className="w-full rounded-md border border-gray-700 bg-gray-800 px-4 py-2 text-sm text-white focus:outline-none focus:ring-2 focus:ring-emerald-500"
+                    />
+                  )}
+                </div>
+              )) : (
+                <p className="text-sm text-gray-500">Nenhum campo editável disponível para este perfil.</p>
+              )}
+
+              <button
+                onClick={handleUpdate}
+                disabled={loading}
+                className="rounded-md bg-emerald-600 px-4 py-2 text-sm font-medium text-white hover:bg-emerald-500 disabled:cursor-not-allowed disabled:opacity-60"
+              >
+                {loading ? 'Salvando...' : 'Salvar alterações'}
+              </button>
+            </div>
+          ) : (
+            <p className="text-sm text-gray-500">Selecione um usuário na lista para editar os dados.</p>
+          )}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/src/lib/supabaseAdmin.ts
+++ b/src/lib/supabaseAdmin.ts
@@ -1,0 +1,15 @@
+import { createClient } from '@supabase/supabase-js';
+
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('Missing Supabase environment variables for admin client.');
+}
+
+export const supabaseAdmin = createClient(supabaseUrl, serviceRoleKey, {
+  auth: {
+    autoRefreshToken: false,
+    persistSession: false,
+  },
+});


### PR DESCRIPTION
## Summary
- add a dedicated admin dashboard page that aggregates monitoring, user management, notification, chat, payment and data browsing widgets
- implement client components for running health tests, reviewing registration flow status, editing users, sending alerts/notifications, handling support chats, listing tables and reporting PIX/USDT activity
- expose server-side admin API routes using the Supabase service role key for notifications, alerts, chat replies, payment summaries and registration flow metrics

## Testing
- `npm run lint` *(fails: existing lint errors in legacy pages not touched in this change)*

------
https://chatgpt.com/codex/tasks/task_b_68d9d55886148333ac8ddffb23600ed1